### PR TITLE
Add on cluster clause while creating intermediate table 

### DIFF
--- a/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/clickhouse/macros/materializations/incremental/incremental.sql
@@ -256,7 +256,7 @@
       {{ get_create_table_as_sql(False, new_data_relation, sql) }}
     {%- endcall %}
     {% call statement('main') -%}
-        create table {{ intermediate_relation }} as {{ existing_relation }}
+        create table {{ intermediate_relation }} {{ on_cluster_clause(existing_relation) }} as {{ existing_relation }}
     {%- endcall %}
     {% call statement('insert_new_data') -%}
         insert into {{ intermediate_relation }} select * from {{ new_data_relation }}


### PR DESCRIPTION

## Summary
<!-- A short description of the changes with a link to an open issue. -->
Add cluster clause so insert_overwrite works with Atomic engine 


